### PR TITLE
fixed positioning of offers details

### DIFF
--- a/src/components/OfferDetails/OfferDetails.css
+++ b/src/components/OfferDetails/OfferDetails.css
@@ -59,10 +59,11 @@
 .offer-details__offers {
   margin: 50px 20px 0 10px;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
 }
 
 .offer-details__offers--base, .offer-details__offers--extended, .offer-details__offers--extra {
+  width: 33%;
   box-shadow: 1px 1px 9px 5px #a9a9a994;
   padding: 0 0 15px 0;
   display: flex;


### PR DESCRIPTION
Po rozmowie z SA poprawiłem pozycjonowanie szczegółów ofert (w razie gdy jakaś opcja nie jest wypełniona to pozostałe oferty są wyśrodkowywane + zawsze mają ustaloną szerokość 33%)