### PR TITLE
Fix bug - activate all offer descriptions if offer extra was filled

### DIFF
--- a/src/components/Add/Form/Form.jsx
+++ b/src/components/Add/Form/Form.jsx
@@ -48,12 +48,13 @@ class AddForm extends Component {
       offerExtraDisabled: true,
       offerExtendedRequired: false,
       offerExtraRequired: false,
+      offerExtraFilled: false,
       priceExtendedRequired: false,
       priceExtraRequired: false,
       fireRedirect: false,
     };
 
-    this.setFieldStateValues = this.setFieldStateValues.bind(this);
+    this.setFieldStateValue = this.setFieldStateValue.bind(this);
     this.checkFormValidity = this.checkFormValidity.bind(this);
     this.getInputReferences = this.getInputReferences.bind(this);
     this.gatherFormData = this.gatherFormData.bind(this);
@@ -77,7 +78,7 @@ class AddForm extends Component {
     ];
   }
 
-  setFieldStateValues(field, value) {
+  setFieldStateValue(field, value) {
     if (this.state[field] !== value) {
       this.setState({ [field]: value });
     }
@@ -189,7 +190,8 @@ class AddForm extends Component {
                   ref={(v) => { this.basicArea = v; }}
                   label={t('components.add.form.offerBaseLabel')}
                   placeholder={t('components.add.form.offerBasePlaceholder')}
-                  onChange={this.setFieldStateValues}
+                  offerExtraFilled={this.state.offerExtraFilled}
+                  onChange={this.setFieldStateValue}
                   required
                 />
               </div>
@@ -209,7 +211,7 @@ class AddForm extends Component {
                   ref={(v) => { this.extendedArea = v; }}
                   label={t('components.add.form.offerExtendedLabel')}
                   placeholder={t('components.add.form.offerExtendedPlaceholder')}
-                  onChange={this.setFieldStateValues}
+                  onChange={this.setFieldStateValue}
                   disabled={this.state.offerExtendedDisabled}
                   required={this.state.offerExtendedRequired}
                 />
@@ -219,7 +221,7 @@ class AddForm extends Component {
                   name="offer__extended-price"
                   ref={(v) => { this.extendedPrice = v; }}
                   placeholder={t('components.add.form.currency')}
-                  onChange={this.setFieldStateValues}
+                  onChange={this.setFieldStateValue}
                   disabled={this.state.offerExtendedDisabled}
                   required={this.state.priceExtendedRequired}
                 />
@@ -232,7 +234,7 @@ class AddForm extends Component {
                   ref={(v) => { this.extraArea = v; }}
                   label={t('components.add.form.offerExtraLabel')}
                   placeholder={t('components.add.form.offerExtraPlaceholder')}
-                  onChange={this.setFieldStateValues}
+                  onChange={this.setFieldStateValue}
                   disabled={this.state.offerExtraDisabled}
                   required={this.state.offerExtraRequired}
                 />
@@ -242,7 +244,7 @@ class AddForm extends Component {
                   name="offer__extra-price"
                   ref={(v) => { this.extraPrice = v; }}
                   placeholder={t('components.add.form.currency')}
-                  onChange={this.setFieldStateValues}
+                  onChange={this.setFieldStateValue}
                   disabled={this.state.offerExtraDisabled}
                   required={this.state.priceExtraRequired}
                 />

--- a/src/components/Login/SignupForm/SignupForm.jsx
+++ b/src/components/Login/SignupForm/SignupForm.jsx
@@ -17,7 +17,7 @@ class SignupForm extends Component {
       fireRedirect: false,
     };
     this.validator = new Validator();
-    this.setFieldStateValues = this.setFieldStateValues.bind(this);
+    this.setFieldStateValue = this.setFieldStateValue.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.getInputReferences = this.getInputReferences.bind(this);
   }
@@ -30,7 +30,7 @@ class SignupForm extends Component {
     ];
   }
 
-  setFieldStateValues(field, value) {
+  setFieldStateValue(field, value) {
     this.setState({ [field]: value });
   }
 
@@ -69,7 +69,7 @@ class SignupForm extends Component {
                 maxLength="30"
                 required
                 validation={this.validator.validateTextInput}
-                onChange={this.setFieldStateValues}
+                onChange={this.setFieldStateValue}
                 isValid={this.state.isValid}
                 checkValidity={this.checkValidity}
                 ref={(v) => { this.nameInput = v; }}
@@ -85,7 +85,7 @@ class SignupForm extends Component {
                 maxLength="50"
                 required
                 validation={this.validator.validateTextInput}
-                onChange={this.setFieldStateValues}
+                onChange={this.setFieldStateValue}
                 isValid={this.state.isValid}
                 checkValidity={this.checkValidity}
                 ref={(v) => { this.surnameInput = v; }}
@@ -100,7 +100,7 @@ class SignupForm extends Component {
                 size="M"
                 required
                 validation={this.validator.validateTextInput}
-                onChange={this.setFieldStateValues}
+                onChange={this.setFieldStateValue}
                 isValid={this.state.isValid}
                 checkValidity={this.checkValidity}
                 ref={(v) => { this.emailInput = v; }}

--- a/src/components/UI/OfferTextarea/OfferTextarea.jsx
+++ b/src/components/UI/OfferTextarea/OfferTextarea.jsx
@@ -39,6 +39,9 @@ class OfferTextarea extends Component {
   activateNextField() {
     if (this.props.name === 'offer__base-description') {
       this.props.onChange('offerExtendedDisabled', false);
+      if (this.props.offerExtraFilled) {
+        this.props.onChange('offerExtraDisabled', false);
+      }
     }
     if (this.props.name === 'offer__extended-description') {
       this.props.onChange('offerExtraDisabled', false);
@@ -46,6 +49,7 @@ class OfferTextarea extends Component {
     }
     if (this.props.name === 'offer__extra-description') {
       this.props.onChange('priceExtraRequired', true);
+      this.props.onChange('offerExtraFilled', true);
     }
   }
 
@@ -60,6 +64,7 @@ class OfferTextarea extends Component {
     }
     if (this.props.name === 'offer__extra-description') {
       this.props.onChange('priceExtraRequired', false);
+      this.props.onChange('offerExtraFilled', false);
     }
   }
 


### PR DESCRIPTION
Poprawiłam na prośbę QA:
"Gdy wypełnimy wszystkie opisy i skasujemy opis podstawowy, po ponownym wpisaniu opisu podstawowego, odblokowują się oba pola opisów: rozszerzony i extra"