### PR TITLE
Obsługa możliwości filtrowania wyników poprzez kliknięcie w odpowiedni link kategorii w stopce

### DIFF
--- a/src/components/App/Footer/Footer.jsx
+++ b/src/components/App/Footer/Footer.jsx
@@ -14,25 +14,110 @@ const Footer = props => (
       </div>
       <div className="footer-top__columns">
         <div className="footer-top__row">
-          <Link to="/search?category=building" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.building')}</Link>
-          <Link to="/search?category=photography" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.photography')}</Link>
-          <Link to="/search?category=companyAndOffice" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.companyAndOffice')}</Link>
-          <Link to="/search?category=graphics" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.graphics')}</Link>
-          <Link to="/search?category=tutoring" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.tutoring')}</Link>
-          <Link to="/search?category=bookkeeping" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.bookkeeping')}</Link>
-          <Link to="/search?category=marketingAndAdvertising" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.marketingAndAdvertising')}</Link>
-          <Link to="/search?category=repairAndService" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.repairAndService')}</Link>
-          <Link to="/search?category=garden" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.garden')}</Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=building', category: 'building' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.building')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=photography', category: 'photography' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.photography')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=companyAndOffice', category: 'companyAndOffice' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.companyAndOffice')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=graphics', category: 'graphics' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.graphics')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=tutoring', category: 'tutoring' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.tutoring')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=bookkeeping', category: 'bookkeeping' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.bookkeeping')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=marketingAndAdvertising', category: 'marketingAndAdvertising' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.marketingAndAdvertising')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=repairAndService', category: 'repairAndService' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.repairAndService')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=garden', category: 'garden' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.garden')}
+          </Link>
         </div>
         <div className="footer-top__row">
-          <Link to="/search?category=housework" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.housework')}</Link>
-          <Link to="/search?category=law" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.law')}</Link>
-          <Link to="/search?category=programming" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.programming')}</Link>
-          <Link to="/search?category=translations" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.translations')}</Link>
-          <Link to="/search?category=transport" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.transport')}</Link>
-          <Link to="/search?category=workshopServices" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.workshopServices')}</Link>
-          <Link to="/search?category=bandsAndMusic" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.bandsAndMusic')}</Link>
-          <Link to="/search?category=others" className="footer-top__row--link">{props.t('components.UI.categorySelect.categoryOptions.others')}</Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=housework', category: 'housework' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.housework')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=law', category: 'law' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.law')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=programming', category: 'programming' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.programming')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=translations', category: 'translations' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.translations')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=transport', category: 'transport' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.transport')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=workshopServices', category: 'workshopServices' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.workshopServices')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=bandsAndMusic', category: 'bandsAndMusic' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.bandsAndMusic')}
+          </Link>
+          <Link
+            to={{ pathname: '/search', search: '?category=others', category: 'others' }}
+            className="footer-top__row--link"
+          >
+            {props.t('components.UI.categorySelect.categoryOptions.others')}
+          </Link>
         </div>
         <div className="footer-top__row">
           <Link to="/" className="footer-top__row--link">{props.t('components.UI.footer.aboutUs.privacy')}</Link>

--- a/src/components/Homepage/CategoryList/Category/Category.jsx
+++ b/src/components/Homepage/CategoryList/Category/Category.jsx
@@ -13,7 +13,7 @@ class Category extends React.Component {
   render() {
     const { t } = this.props;
     return (
-      <Link href="/" to={`/search?category=${this.props.category}`} className="category">
+      <Link to={`/search?category=${this.props.category}`} className="category">
         <img
           className="category__img"
           src={`assets/images/categories/category_${this.props.category}.png`}

--- a/src/components/Homepage/CategoryList/CategoryList.jsx
+++ b/src/components/Homepage/CategoryList/CategoryList.jsx
@@ -22,11 +22,16 @@ class CategoryList extends React.Component {
     const seeMoreButton = this.state.hidden
       ? (
         <button className="category-list__arrow" onClick={this.toggleHidden}>
-          <span className="category-list__arrow-caption category-list__arrow-caption--more">{t('components.categoryList.seeMore')}</span>
+          <span className="category-list__arrow-caption category-list__arrow-caption--more">
+            {t('components.categoryList.seeMore')}
+          </span>
         </button>
-      ) : (
+      )
+      : (
         <button className="category-list__arrow category-list__arrow--up" onClick={this.toggleHidden}>
-          <span className="category-list__arrow-caption category-list__arrow-caption--less">{t('components.categoryList.seeLess')}</span>
+          <span className="category-list__arrow-caption category-list__arrow-caption--less">
+            {t('components.categoryList.seeLess')}
+          </span>
         </button>
       );
     return (

--- a/src/components/Search/SearchResults/FoundSearchResults/FoundSearchResults.jsx
+++ b/src/components/Search/SearchResults/FoundSearchResults/FoundSearchResults.jsx
@@ -49,10 +49,18 @@ class SearchResults extends React.Component {
             {t('components.foundSearchResults.resultsTitle')}
           </h3>
           <div className="search-results__heading">
-            <span className="search-results__heading-item search-results__heading-wide">{t('components.foundSearchResults.offerTitle')}</span>
-            <span className="search-results__heading-item search-results__heading-narrow">{t('components.foundSearchResults.category')}</span>
-            <span className="search-results__heading-item search-results__heading-narrow">{t('components.foundSearchResults.price')}</span>
-            <span className="search-results__heading-item search-results__heading-narrow">{t('components.foundSearchResults.date')}</span>
+            <span className="search-results__heading-item search-results__heading-wide">
+              {t('components.foundSearchResults.offerTitle')}
+            </span>
+            <span className="search-results__heading-item search-results__heading-narrow">
+              {t('components.foundSearchResults.category')}
+            </span>
+            <span className="search-results__heading-item search-results__heading-narrow">
+              {t('components.foundSearchResults.price')}
+            </span>
+            <span className="search-results__heading-item search-results__heading-narrow">
+              {t('components.foundSearchResults.date')}
+            </span>
           </div>
           <ol className="search-results__list">
             {this.props.services.map((service, i) => (

--- a/src/screens/Search/Search.jsx
+++ b/src/screens/Search/Search.jsx
@@ -35,6 +35,15 @@ export default class SearchScreen extends React.Component {
     this.getData();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.location.category !== nextProps.location.category) {
+      const getDataWithReceivedProps = this.getData.bind(this);
+      const category = new URLSearchParams(nextProps.location.search).get('category');
+
+      this.setState({ category }, getDataWithReceivedProps);
+    }
+  }
+
   onSubmit() {
     if (!this.state.isValidPhrase) return;
 


### PR DESCRIPTION
- Dodałem do linków w stopce location descriptor (pathname i search), aby link przenosił do strony z wynikami wyszukiwania i jednocześnie umieszczał w URL daną kategorię w formie np.  `?category=building`. 
- W komponencie wyszukiwania dodałem componentWillReceiveProps, który reaguje na zmianę propsów tworząc nowy obiekt URLSearchParams, za jego pomocą wyciągając z URL nazwę kategorii, uaktualniając stan komponentu i wywołując metodę `getData()`;

Innymi słowy pomyślałem, że filtrowanie za pomocą klikania w linki do kategorii znajdujące się w stopce można będzie obsłużyć w następujący sposób: Kliknięcie w link przenosi użytkownika na stronę wyszukiwarki i jednocześnie umieszcza w URL nazwę kategorii; zmiana propsów powoduje wydobycie kategorii z URL, uaktualnienie stanu komponentu i pobranie nowych wyników wyszukiwania. To w miarę proste podejście pozwala uniknąć przeładowywania całej strony, używania contextu, czy łańcuchowego przekazywania propsów w drzewie komponentów, ale nie wiem, czy jest ono w ogóle słuszne. Chętnie wysłucham Waszych opinii, albo pomysłów jak rozwiązać to lepiej ;)