### PR TITLE
Poprawa filtrowania wyników przez klikanie w odnośniki w stopce

### DIFF
--- a/src/screens/Search/Search.jsx
+++ b/src/screens/Search/Search.jsx
@@ -40,7 +40,11 @@ export default class SearchScreen extends React.Component {
       const getDataWithReceivedProps = this.getData.bind(this);
       const category = new URLSearchParams(nextProps.location.search).get('category');
 
-      this.setState({ category }, getDataWithReceivedProps);
+      this.setState({
+        category,
+        paginationData: { pageNumber: 1 },
+        page: 1,
+      }, getDataWithReceivedProps);
     }
   }
 


### PR DESCRIPTION
Wyniki i numery stron powinny się teraz ładować i wyświetlać prawidłowo.